### PR TITLE
rank_gene_group_fix for rapids-23.02

### DIFF
--- a/notebooks/rapids_scanpy_funcs.py
+++ b/notebooks/rapids_scanpy_funcs.py
@@ -436,8 +436,9 @@ def rank_genes_groups(
     
     clf = LogisticRegression(**kwds)
     clf.fit(X, grouping_logreg)
-    scores_all = cp.array(clf.coef_).T
-    
+    scores_all = cp.array(clf.coef_)
+    if len(groups_order)== scores_all.shape[1]:
+        scores_all= scores_all.T
     for igroup, group in enumerate(groups_order):
         if len(groups_order) <= 2:  # binary logistic regression
             scores = scores_all[0]


### PR DESCRIPTION
`LogisticRegression.coef_` is transposed in rapids-23.02.
This makes PR makes sure both cases (rapids<23.02 and rapids==23.02) are handled.